### PR TITLE
Refactoring to be be exclusively a plugin

### DIFF
--- a/examples/js-main/index.html
+++ b/examples/js-main/index.html
@@ -2,9 +2,7 @@
 <html>
   <body>
     <script src="../../dist/steal.production.js" main="examples/js-main/index">
-      import loader from '@loader';
-
-      loader.import(loader.main)
+      System.import(System.main)
         .then(function({ render }) {
           render(document.body);
         });

--- a/examples/ts-main/index.html
+++ b/examples/ts-main/index.html
@@ -2,9 +2,7 @@
 <html>
   <body>
     <script src="../../dist/steal.production.js" main="examples/ts-main/src/index.ts!steal-typescript">
-      import loader from '@loader';
-
-      loader.import(loader.main)
+      System.import(System.main)
         .then(function({ render }) {
           render(document.body);
         });

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/phillipskevin/steal-typescript"
   },
   "scripts": {
-    "lint": "eslint typescript.js createProgram.js",
+    "lint": "eslint typescript.js createProgram.js utils.js",
     "preversion": "npm test",
     "postversion": "git push --tags && git push",
     "test": "npm run lint && npm run test-browser && npm run test-node",
     "test-browser": "testee test/test.html --browsers firefox",
-    "test-node": "mocha test/test-node.js --timeout 60000",
+    "test-node": "mocha test/test-build.js test/test-utils.js --timeout 60000",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish"

--- a/test/test-build.js
+++ b/test/test-build.js
@@ -3,7 +3,7 @@ var assert = require('chai').assert;
 var spawn = require('child_process').spawn;
 var stealTools = require('steal-tools');
 
-describe('steal-typescript', function() {
+describe('steal-typescript - build', function() {
     it('build - js-main', function() {
       return stealTools.build({
         config: __dirname + '/../package.json!npm',

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,0 +1,86 @@
+var mocha = require('mocha');
+var assert = require('chai').assert;
+
+var utils = require('../utils');
+
+describe('steal-typescript - utils', function() {
+  it('correctRelativeImports', function() {
+    var correctRelativeImports = utils.correctRelativeImports;
+
+    assert.deepEqual(
+      correctRelativeImports(
+        'define(["foo","./bar","../baz"], function(foo, bar, baz) {});',
+        'abc/xyz'
+      ),
+      'define(["foo","abc/xyz/bar","abc/baz"], function(foo, bar, baz) {});',
+      'basics work');
+
+    assert.deepEqual(
+      correctRelativeImports(
+        'define(["foo","./bar","../baz"], function(foo, bar, baz) {});',
+        'abc/xyz',
+        'ts'
+      ),
+      'define(["foo","abc/xyz/bar.ts","abc/baz.ts"], function(foo, bar, baz) {});',
+      'passing an extension works');
+
+    assert.deepEqual(
+      correctRelativeImports(
+        "function aFunction() { console.log('blah'); }" +
+        'define(["foo", "./bar", "../baz"], function(foo, bar) {});',
+        'abc/xyz'
+      ),
+      "function aFunction() { console.log('blah'); }" +
+      'define(["foo","abc/xyz/bar","abc/baz"], function(foo, bar) {});',
+      'works when there is other code before define block');
+  });
+
+  it('normalize', function() {
+    var normalize = utils.normalize;
+
+    assert.equal(normalize('foo/bar/./baz'), 'foo/bar/baz', './ works');
+    assert.equal(normalize('foo/bar/../baz'), 'foo/baz', '../ works');
+  });
+
+
+  it('dissectModuleName', function() {
+    var dissectModuleName = utils.dissectModuleName;
+
+    var path = 'examples/ts-main/src';
+    var file = 'index.ts';
+    var plugin = 'steal-typescript@0.4.0#typescript';
+    var project = '';
+
+    assert.deepEqual(
+      // examples/ts-main/src/index.ts!steal-typescript@0.4.0#typescript
+      dissectModuleName(
+        project + '#' +
+        path + '/' +
+        file + '!' +
+        plugin
+      ), {
+        project: project,
+        path: path,
+        file: path + '/' + file,
+        plugin: plugin
+      });
+  });
+
+  it('moduleName', function() {
+    var moduleName = utils.moduleName;
+
+    assert.equal(
+      moduleName(
+        '/home/kevin/dev/steal-typescript/examples/ts-main/src/exclaim.js',
+        'examples/ts-main/src'
+      ),
+      'examples/ts-main/src/exclaim'
+      );
+  });
+
+  it('removeExtension', function() {
+    var removeExtension = utils.removeExtension;
+
+    assert.equal(removeExtension('foo/bar/baz.xyz'), 'foo/bar/baz');
+  });
+});

--- a/typescript.js
+++ b/typescript.js
@@ -1,6 +1,6 @@
 var loader = require('@loader');
 var ts = require('typescript');
-var assign = require('object-assign');
+var utils = require('./utils');
 
 // translate hook will transpile TypeScript to JavaScript
 // hook will only be called for .ts files
@@ -19,11 +19,14 @@ exports.translate = function(load) {
     });
   } else {
     // transpile a single TypeScript module for development mode
-    transpileModule(load, compilerOptions, useSourceMap);
+    load.source = transpileModule(load, compilerOptions, useSourceMap);
+    load.source = utils.correctRelativeImports(load.source,
+        utils.dissectModuleName(load.name).path, 'ts');
   }
 };
 
 function transpileModule(load, compilerOptions, useSourceMap) {
+  var source = '';
   var sourceMapDelimiter = '//# sourceMappingURL=';
 
   var result = ts.transpileModule(load.source, {
@@ -31,14 +34,16 @@ function transpileModule(load, compilerOptions, useSourceMap) {
     compilerOptions: compilerOptions
   });
 
-  load.source = result.outputText;
+  source = result.outputText;
 
   if (useSourceMap) {
     // remove default source map
-    load.source = load.source.slice(0, load.source.indexOf(sourceMapDelimiter));
+    source = source.slice(0, source.indexOf(sourceMapDelimiter));
     // add inline sourcemap
-    load.source += sourceMapDelimiter + formatSourceMap(JSON.parse(result.sourceMapText), load.source);
+    source += sourceMapDelimiter + formatSourceMap(JSON.parse(result.sourceMapText), source);
   }
+
+  return source;
 }
 
 // convert source map from V3 format to base64
@@ -48,50 +53,4 @@ function formatSourceMap(sourceMap, orig){
   sourceMap.sourcesContent = [orig];
   sourceMap = JSON.stringify(sourceMap);
   return 'data:application/json;base64,' + btoa(unescape(encodeURIComponent(sourceMap)));
-}
-
-var addTypeScriptExtension = function(loader) {
-  // relative imports from typescript files are normalized incorrectly
-  // so normalize as if the parent is a `.js` file and then correct
-  var _normalize = loader.normalize;
-  loader.normalize = function(moduleIdentifier, parentName) {
-    var parentParts = parentName && parentName.split('!');
-    var parentPlugin = parentParts && parentParts[1] || '';
-    var isRelativePath = moduleIdentifier.startsWith('./') || moduleIdentifier.startsWith('../');
-    var parentNameAsJs = parentParts && parentParts[0].slice(0, -3) + '.js';
-
-    if (parentPlugin.includes('steal-typescript') && isRelativePath) {
-      // normalize as if the parent is a `.js` file,
-      // then change the extension and add plugin
-      return _normalize.apply(loader, [moduleIdentifier, parentNameAsJs])
-        .then(function(moduleName) {
-          return moduleName + '.ts!' + parentPlugin;
-        });
-    } else {
-      return _normalize.apply(loader, arguments);
-    }
-  };
-
-  // Try to fetch files as `.ts` before `.js`
-  var _fetch = loader.fetch;
-  loader.fetch = function(load) {
-    var args = arguments;
-
-    // if we are loading a .js file, try loading a .ts file first
-    var address = load.address.endsWith('.js') ? load.address.slice(0, -3) + '.ts' : load.address;
-
-    var tsLoad = assign({}, load, {
-      address: address
-    });
-
-    return _fetch
-      .call(loader, tsLoad)
-      .catch(function() {
-        return _fetch.apply(loader, args);
-      });
-  };
-};
-
-if (typeof System !== 'undefined') {
-  addTypeScriptExtension(System);
 }

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,86 @@
+// make relative imports from TypeScript files not relative
+// `./b` -> `<rootDir>/b.ts`
+function correctRelativeImports(source, rootDir, extension) {
+  extension = extension ? ('.' + extension) : '';
+  var startString = 'define([';
+  var endString = ']';
+
+  var importsStart = source.indexOf(startString) + startString.length - 1;
+  var importsEnd = source.indexOf(endString, importsStart) + 1;
+
+  var imports = JSON.parse(source.slice(importsStart, importsEnd));
+
+  imports = imports.map(function(imp) {
+    return imp.startsWith('./') || imp.startsWith('../') ?
+      normalize(rootDir + '/' + imp) + extension :
+      imp;
+  });
+
+  return source.slice(0, importsStart) + JSON.stringify(imports) + source.slice(importsEnd);
+}
+
+// handle any `./`s or `../`s in path
+function normalize(path) {
+  return path
+    // foo/./bar -> foo/bar
+    .replace(/\/\.\//g, '/')
+    // foo/bar/../baz -> foo/baz
+    .replace(/\/\w*\/\.\.\//g, '/');
+}
+
+// takes a moduleName like
+// examples/ts-main/src/index.ts!steal-typescript@0.4.0#typescript
+//
+// return a path like
+// examples/ts-main/src
+function dissectModuleName(moduleName) {
+  var moduleParts = moduleName.split('!');
+  var nameWithoutPlugin = moduleParts[0];
+  var plugin = moduleParts[1];
+  var parts = nameWithoutPlugin.split('#');
+  var project, file;
+
+  if (parts.length > 1) {
+    project = parts[0].split('@')[0];
+    file = parts.length ? parts[1] : '';
+  } else {
+    project = '';
+    file = parts[0].split('@')[0];
+  }
+
+  var lastSlashIndex = file && file.lastIndexOf('/');
+  var rootDir = lastSlashIndex > 0 ?
+    ((project ? project + '/' : '') + file.slice(0, lastSlashIndex)) :
+    project;
+
+  return {
+    project: project,
+    path: rootDir,
+    file: file,
+    plugin: plugin
+  };
+}
+
+// takes a fileName like
+// /home/kevin/dev/steal-typescript/examples/ts-main/src/exclaim.js
+// and a rootDir like
+// examples/ts-main/src
+//
+// returns a module name like
+// examples/ts-main/src/exclaim
+function moduleName(fileName, rootDir) {
+  var index = fileName.indexOf(rootDir);
+  return removeExtension(fileName.slice(index));
+}
+
+function removeExtension(file) {
+  return file.replace(/\.\w*$/, '');
+}
+
+module.exports = {
+  correctRelativeImports: correctRelativeImports,
+  normalize: normalize,
+  dissectModuleName: dissectModuleName,
+  moduleName: moduleName,
+  removeExtension: removeExtension
+};


### PR DESCRIPTION
Previously this tried to mix being a plugin with being an extension
(overwriting loader.fetch, loader.normalize) which caused lots of problems and inconsistent behavior. Now it is just a plugin that exports a translate hook that will transpile in development and compile an entire TypeScript program in production. This also removes lots of 404 errors because we
are not trying to fetch anything as a .ts file other than what steal
does automatically (as well as any relative imports from other .ts
files).